### PR TITLE
rf: fix local short variable renaming

### DIFF
--- a/testdata/mv_localshortvar.txt
+++ b/testdata/mv_localshortvar.txt
@@ -1,0 +1,21 @@
+mv F.x F.y
+-- x.go --
+package m
+
+func F() {
+	x := 123
+	_ = x
+}
+-- stdout --
+diff old/x.go new/x.go
+--- old/x.go
++++ new/x.go
+@@ -1,6 +1,6 @@
+ package m
+
+ func F() {
+-	x := 123
+-	_ = x
++	y := 123
++	_ = y
+ }

--- a/testdata/mv_localvar.txt
+++ b/testdata/mv_localvar.txt
@@ -1,0 +1,21 @@
+mv F.x F.y
+-- x.go --
+package m
+
+func F() {
+	var x int = 123
+	_ = x
+}
+-- stdout --
+diff old/x.go new/x.go
+--- old/x.go
++++ new/x.go
+@@ -1,6 +1,6 @@
+ package m
+
+ func F() {
+-	var x int = 123
+-	_ = x
++	var y int = 123
++	_ = y
+ }


### PR DESCRIPTION
Renaming of local variables declared with a VarDecl ('var x int') were
already working, but ShortVarDecl ('x := 0') variables were broken
because rewriteDefn didn't handle AssignStmt declarations.

To avoid breaking mv_funcvar.txt, removeDecl now updates the AssignStmt
token when deleting the colon so that rewriteUses can skip definitions,
which aren't considered uses since rewriteDefn already did the rewrite.
Otherwise both would make duplicate edits.

Fixes #13