### PR TITLE
refactor: keep blank imports

### DIFF
--- a/refactor/imports.go
+++ b/refactor/imports.go
@@ -37,12 +37,15 @@ func deleteUnusedImports(s *Snapshot, p *Package, text []byte) []byte {
 	})
 
 	match := func(name, pkg string) bool {
-		if name == "" {
+		switch name {
+		case "":
 			p1 := s.pkgByID[s.importToID(p, pkg)]
 			if p1 == nil {
 				panic("NO IMPORT: " + pkg)
 			}
 			name = p1.Name
+		case "_":
+			return false
 		}
 		return !used[name]
 	}

--- a/testdata/mv_const_pkg.txt
+++ b/testdata/mv_const_pkg.txt
@@ -2,7 +2,9 @@ mv T X m/q
 -- x.go --
 package p
 
-import _ "m/q"
+import (
+	_ "m/q"
+)
 
 type T int
 
@@ -13,10 +15,10 @@ package q
 diff old/x.go new/x.go
 --- old/x.go
 +++ new/x.go
-@@ -1,7 +1 @@
- package p
--
--import _ "m/q"
+@@ -3,7 +3,3 @@
+ import (
+ 	_ "m/q"
+ )
 -
 -type T int
 -

--- a/testdata/rm_import.txt
+++ b/testdata/rm_import.txt
@@ -6,6 +6,7 @@ package p
 import (
 	"bytes"
 	"fmt"
+	_ "embed"
 	"strings"
 )
 
@@ -17,11 +18,12 @@ var F = fmt.Printf
 diff old/x.go new/x.go
 --- old/x.go
 +++ new/x.go
-@@ -2,11 +2,8 @@
+@@ -2,12 +2,9 @@
 
  import (
  	"bytes"
 -	"fmt"
+ 	_ "embed"
  	"strings"
  )
 


### PR DESCRIPTION
Previously blank imports were always removed which prevents using packages for init-only purposes. Updated tests to reflect this changes.