### PR TITLE
git-generate: clean gitdir filepath on Windows

### DIFF
--- a/git-generate/main.go
+++ b/git-generate/main.go
@@ -40,6 +40,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -64,6 +65,11 @@ func main() {
 	}
 
 	gitdir := strings.TrimSpace(git("rev-parse", "--show-toplevel"))
+	if runtime.GOOS == "windows" {
+		// Convert to path with filepath.Separator so that prefix-based
+		// relative path computation in walkDir works on Windows too.
+		gitdir = filepath.Clean(gitdir)
+	}
 
 	if *file != "" && *conflict {
 		log.Fatalf("cannot use -conflict with -f")


### PR DESCRIPTION
For some reason, on Windows, git prints the path with '/' separators instead of '\\'. This by itself isn't a problem, but it intersects poorly with prefix-based relative path computation in walkGit:

	cannot compute relative path: C:/reporoot vs C:\reporoot\file.txt

We could solve that by using filepath.Rel, but since cleaning the path is all it takes to let the prefix-based computation work on Windows too, pick that for now.

Tested on a Windows machine.

Fixes #30.