### PR TITLE
git-generate: use git cat-file to get the raw commit message body

### DIFF
--- a/git-generate/main.go
+++ b/git-generate/main.go
@@ -99,8 +99,11 @@ func main() {
 			script = readScript(msg, "")
 		}
 	} else {
-		msg := git("log", "-n1", what)
-		script = readScript(msg, "    ")
+		_, msg, ok := strings.Cut(git("cat-file", "commit", what), "\n\n")
+		if !ok {
+			log.Fatalf("internal error: blank line not found in 'git cat-file commit %s' output", what)
+		}
+		script = readScript(msg, "")
 	}
 
 	if len(script) == 0 {


### PR DESCRIPTION
The git log command is considered porcelain, and by default it expands tabs into spaces, which can break some scripts that are sensitive to whitespace changes. It's possible to add the --no-expand-tabs flag to disable that behavior, but perhaps it's better still to switch to a plumbing command to extract the commit message body as it is. This way there's no need to strip the 4 leading spaces either.

Tested with a patch file that git-generate successfully applies after this fix, something it couldn't do before.

Fixes #31.