### PR TITLE
rf: use stable go version in github actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,11 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.16
-      uses: actions/setup-go@v2
+    - name: Set up Go
+      uses: actions/setup-go@v5
       with:
-        stable: false
-        go-version: '1.16.0'
+        go-version: 'stable'
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2


### PR DESCRIPTION
Use the stable version of go as per [Github Actions documentation](https://github.com/actions/setup-go?tab=readme-ov-file#using-stableoldstable-aliases).