### PR TITLE
rf: add test for removing via text ranges

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -359,8 +359,6 @@
 // When deleting a declaration, rm also deletes line comments
 // immediately preceding it, up to a blank line.
 //
-// UNIMPLEMENTED: removal of struct fields, interface methods, text ranges.
-//
 // # Bugs Bugs Bugs
 //
 // Rf is very very rough. Everything is subject to change, and it may break your programs.

--- a/testdata/rm_addr5.txt
+++ b/testdata/rm_addr5.txt
@@ -1,0 +1,26 @@
+rm x.go:4,6
+rm x.go:6
+-- x.go --
+package p
+
+func Main() {
+	{
+		hello()
+	}
+}
+
+func hello() {}
+-- stdout --
+diff old/x.go new/x.go
+--- old/x.go
++++ new/x.go
+@@ -1,9 +1,4 @@
+ package p
+
+ func Main() {
+-	{
+-		hello()
+-	}
+ }
+-
+-func hello() {}


### PR DESCRIPTION
This change adds a test for the `rm` command, wherein the removal is done by specifying a text range.

Documentation is also updated to reflect that the `rm` command implements the removal of struct fields (see `testdata/rm_field.txt`), and the removal of interface methods (see `testdata/rm_iface.txt`).