### PR TITLE
rf: improve detection of `unsafe` special case

### DIFF
--- a/refactor/snap.go
+++ b/refactor/snap.go
@@ -197,7 +197,7 @@ func (r *Refactor) load1(config Config) ([]*Snapshot, error) {
 	if err != nil {
 		return nil, err
 	}
-	cmdList := append(append([]string{"list", "-e", "-json", "-compiled", "-test", "-deps"}, cfgFlags...), "./...")
+	cmdList := append(append([]string{"list", "-e", "-pgo=off", "-json", "-compiled", "-test", "-deps"}, cfgFlags...), "./...")
 	cmd = exec.Command("go", cmdList...)
 	cmd.Dir = r.modRoot
 	cmd.Env = append(append(os.Environ(), "PWD="+r.modRoot), cfgEnvs...)


### PR DESCRIPTION
When using profile guided optimization, the PkgPath can contain a suffix with the binary in question.  For example, the PkgPath:
  `unsafe [cmd/compile]`
was encountered when executing rf in the cmd/go subtree.  This commit uses a regex to better identify when the special case of the `unsafe` package should apply.  Note that we need to be cautious not to falsely match a package such as `unsafeheader`.