### PR TITLE
rf: check import map if initial lookup fails

### DIFF
--- a/refactor/imports.go
+++ b/refactor/imports.go
@@ -40,6 +40,11 @@ func deleteUnusedImports(s *Snapshot, p *Package, text []byte) []byte {
 		if name == "" {
 			p1 := s.pkgGraph.byPath(pkg)
 			if p1 == nil {
+				if val, ok := p.ImportMap[pkg]; ok {
+					p1 = s.pkgGraph.pkgByPath[val]
+				}
+			}
+			if p1 == nil {
 				panic("NO IMPORT: " + pkg)
 			}
 			name = p1.Name


### PR DESCRIPTION
This commit adds an additional search in the package importMap if the initial lookup fails.  If the importMap has a key matching the dependency, then the package graph is searched for the corresponding value of the importMap.

This was discovered when the `cmd/go/internal/modload` package attempted to import `modfile` via `golang.org/x/mod/modfile` which did not exist in the package graph.  However, the importMap contained the entry:
  golang.org/x/mod/modfile" -> "cmd/vendor/golang.org/x/mod/modfile"

The vendored path was in the package graph, and therefore was used in place of the non-vendored path.