### PR TITLE
rf: consistent pkg lookup

### DIFF
--- a/refactor/imports.go
+++ b/refactor/imports.go
@@ -38,11 +38,12 @@ func deleteUnusedImports(s *Snapshot, p *Package, text []byte) []byte {
 
 	match := func(name, pkg string) bool {
 		if name == "" {
-			p1 := s.pkgGraph.byPath(pkg)
+			var p1 *Package
+			if path, ok := p.ImportMap[pkg]; ok {
+				p1 = s.pkgGraph.byPath(path)
+			}
 			if p1 == nil {
-				if val, ok := p.ImportMap[pkg]; ok {
-					p1 = s.pkgGraph.pkgByPath[val]
-				}
+				p1 = s.pkgGraph.byPath(pkg)
 			}
 			if p1 == nil {
 				panic("NO IMPORT: " + pkg)


### PR DESCRIPTION
This commit aligns refactor/imports.go:[deleteUnusedImports] with how we do package lookup in snap.go:[Import].  Specifially, we allow a package's ImportMap to override the path that we are searching for in the package graph.