### PR TITLE
rf: consistent import path lookup

### DIFF
--- a/refactor/imports.go
+++ b/refactor/imports.go
@@ -36,17 +36,11 @@ func deleteUnusedImports(s *Snapshot, p *Package, text []byte) []byte {
 		}
 	})
 
-	match := func(name, pkg string) bool {
+	match := func(name, importPath string) bool {
 		if name == "" {
-			var p1 *Package
-			if path, ok := p.ImportMap[pkg]; ok {
-				p1 = s.pkgGraph.byPath(path)
-			}
+			p1 := s.pkgGraph.byPath(p.ImportMap.Lookup(importPath))
 			if p1 == nil {
-				p1 = s.pkgGraph.byPath(pkg)
-			}
-			if p1 == nil {
-				panic("NO IMPORT: " + pkg)
+				panic("NO IMPORT: " + importPath)
 			}
 			name = p1.Name
 		}


### PR DESCRIPTION
This commit refactors how we lookup a package path from an import path.  The terms "importPath" and "pkgPath" are used to help distinguish when we are using the different concepts of path values.