### PR TITLE
rf: fix escaped quote detection

### DIFF
--- a/rf.go
+++ b/rf.go
@@ -277,6 +277,13 @@ func readLine(text string) (line, rest string, err error) {
 
 		case c == '\\':
 			j := i + 1
+			if j < len(text) && (text[j] == '\'' || text[j] == '"') {
+				keep.WriteString(text[start:i])
+				keep.WriteByte(text[j])
+				start = j + 1
+				i = j + 1
+				continue
+			}
 			for j < len(text) && text[j] == ' ' || text[j] == '\t' {
 				j++
 			}

--- a/rf_test.go
+++ b/rf_test.go
@@ -48,6 +48,30 @@ var readLineTests = []struct {
 		in:  "cmd {\nx y\n}\n",
 		out: []string{"cmd {\nx y\n}"},
 	},
+	{
+		in:  "cmd It\\'s not a failure\n",
+		out: []string{"cmd It's not a failure"},
+	},
+	{
+		in:  "cmd 'It\\'s not a failure'\n",
+		out: []string{"cmd 'It\\'s not a failure'"},
+	},
+	{
+		in:  "cmd It\\\"s not a failure\n",
+		out: []string{"cmd It\"s not a failure"},
+	},
+	{
+		in:  "cmd \"It\\\"s not a failure\"\n",
+		out: []string{"cmd \"It\\\"s not a failure\""},
+	},
+	{
+		in:  "cmd It's a failure\n",
+		err: fmt.Errorf("newline in '-quoted string"),
+	},
+	{
+		in:  "cmd It\"s a failure\n",
+		err: fmt.Errorf("newline in \"-quoted string"),
+	},
 }
 
 func TestReadLine(t *testing.T) {


### PR DESCRIPTION
This commit updates the scanning logic in `readline` to allow for escaped quotes within a line.