### PR TITLE
rf: avoid import statement for same package

### DIFF
--- a/inject.go
+++ b/inject.go
@@ -204,6 +204,11 @@ func cmdInject(snap *refactor.Snapshot, args string) error {
 					name = items[0].Name
 					outer := items[0].Outermost()
 					if outer.Kind == refactor.ItemPkg {
+						if pkg.Types == outer.Obj.(*types.PkgName).Imported() {
+							// Don't add an import if we are already in that package
+							name = strings.TrimPrefix(name, outer.Name + ".")
+							return
+						}
 						name = snap.NeedImport(stack[1].Pos(), "", outer.Obj.(*types.PkgName).Imported()) + strings.TrimPrefix(name, outer.Name)
 					}
 				}

--- a/testdata/inject5.txt
+++ b/testdata/inject5.txt
@@ -1,0 +1,59 @@
+inject q.G foo
+-- x.go --
+package p
+
+import "m/q"
+
+func foo() { q.F() }
+
+-- q/q.go --
+package q
+
+var G int
+
+type T struct{}
+
+func F() { g() }
+func g() { g2(1) }
+func g2(g int) { h(g) }
+func h(i int) { var t T; t.j(i+1) }
+func (t T) j(k int) { m(k+G) }
+func m(l int) { println(2*G+l) }
+func z() { h(2) }
+func y() {}
+
+-- stdout --
+diff old/x.go new/x.go
+--- old/x.go
++++ new/x.go
+@@ -2,5 +2,4 @@
+
+ import "m/q"
+
+-func foo() { q.F() }
+-
++func foo() { q.F(q.G) }
+diff old/q/q.go new/q/q.go
+--- old/q/q.go
++++ new/q/q.go
+@@ -4,12 +4,11 @@
+
+ type T struct{}
+
+-func F() { g() }
+-func g() { g2(1) }
+-func g2(g int) { h(g) }
+-func h(i int) { var t T; t.j(i+1) }
+-func (t T) j(k int) { m(k+G) }
+-func m(l int) { println(2*G+l) }
+-func z() { h(2) }
+-func y() {}
+-
++func F(g_ int)             { g(g_) }
++func g(g int)              { g2(g, 1) }
++func g2(g_ int, g int)     { h(g_, g) }
++func h(g int, i int)       { var t T; t.j(g, i+1) }
++func (t T) j(g int, k int) { m(g, k+g) }
++func m(g int, l int)       { println(2*g + l) }
++func z()                   { h(G, 2) }
++func y()                   {}


### PR DESCRIPTION
This commit ensures that we do not add an import statement for the
same package we are already within.
