### PR TITLE
rf: implement mv func -> method

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -258,8 +258,6 @@
 //
 //	mv TFunction T.Method
 //
-// UNIMPLEMENTED.
-//
 // code text → new function
 //
 // A text range can be moved to a new function, leaving behind an appropriate

--- a/testdata/mv_func_to_method.txt
+++ b/testdata/mv_func_to_method.txt
@@ -1,0 +1,62 @@
+mv bar S.foo1
+mv baz S.foo2
+mv Qux S.Foo3
+mv quux S.foo4
+-- p.go --
+package m
+
+type S struct{}
+
+func bar(s S) {}
+func baz(s *S) {}
+func Qux(s *S, x int) {}
+func quux(*S) {}
+
+func xyzzy() {
+	bar(S{})
+	g := &S{}
+	baz(g)
+}
+-- q/q.go --
+package q
+
+import "m"
+
+func plugh() {
+	s := &m.S{}
+	m.Qux(s, 0)
+}
+-- stdout --
+diff old/p.go new/p.go
+--- old/p.go
++++ new/p.go
+@@ -2,13 +2,13 @@
+
+ type S struct{}
+
+-func bar(s S) {}
+-func baz(s *S) {}
+-func Qux(s *S, x int) {}
+-func quux(*S) {}
++func (s S) foo1()       {}
++func (s *S) foo2()      {}
++func (s *S) Foo3(x int) {}
++func (*S) foo4()        {}
+
+ func xyzzy() {
+-	bar(S{})
++	S{}.foo1()
+ 	g := &S{}
+-	baz(g)
++	g.foo2()
+ }
+diff old/q/q.go new/q/q.go
+--- old/q/q.go
++++ new/q/q.go
+@@ -4,5 +4,5 @@
+
+ func plugh() {
+ 	s := &m.S{}
+-	m.Qux(s, 0)
++	s.Foo3(0)
+ }

--- a/testdata/mv_func_to_method2.txt
+++ b/testdata/mv_func_to_method2.txt
@@ -1,0 +1,50 @@
+mv Foo S.Foo1
+-- p.go --
+package m
+
+type S struct{}
+
+func Foo(s S) {}
+
+func xyzzy() {
+	funcvar := Foo
+	_ = funcvar
+}
+-- q/q.go --
+package q
+
+import "m"
+
+func corge(f func(s *m.S)) {}
+
+func plugh() {
+	funcvar := m.Foo
+	_ = funcvar
+}
+-- stdout --
+diff old/p.go new/p.go
+--- old/p.go
++++ new/p.go
+@@ -2,9 +2,9 @@
+
+ type S struct{}
+
+-func Foo(s S) {}
++func (s S) Foo1() {}
+
+ func xyzzy() {
+-	funcvar := Foo
++	funcvar := S.Foo1
+ 	_ = funcvar
+ }
+diff old/q/q.go new/q/q.go
+--- old/q/q.go
++++ new/q/q.go
+@@ -5,6 +5,6 @@
+ func corge(f func(s *m.S)) {}
+
+ func plugh() {
+-	funcvar := m.Foo
++	funcvar := m.S.Foo1
+ 	_ = funcvar
+ }

--- a/testdata/mv_func_to_method3.txt
+++ b/testdata/mv_func_to_method3.txt
@@ -1,0 +1,67 @@
+mv Foo S.Foo1
+mv Bar S.Bar1
+-- p.go --
+package m
+
+type S struct{}
+
+func Foo(s S) {}
+func Bar(s *S) {}
+
+func xyzzy() {
+	foovar := Foo
+	_ = foovar
+	barvar := Bar
+	_ = barvar
+}
+-- q/q.go --
+package q
+
+import "m"
+
+func corge(f func(s *m.S)) {}
+
+func plugh() {
+	foovar := m.Foo
+	_ = foovar
+	barvar := m.Bar
+	corge(m.Bar)
+	corge(barvar)
+}
+-- stdout --
+diff old/p.go new/p.go
+--- old/p.go
++++ new/p.go
+@@ -2,12 +2,12 @@
+
+ type S struct{}
+
+-func Foo(s S) {}
+-func Bar(s *S) {}
++func (s S) Foo1()  {}
++func (s *S) Bar1() {}
+
+ func xyzzy() {
+-	foovar := Foo
++	foovar := S.Foo1
+ 	_ = foovar
+-	barvar := Bar
++	barvar := (*S).Bar1
+ 	_ = barvar
+ }
+diff old/q/q.go new/q/q.go
+--- old/q/q.go
++++ new/q/q.go
+@@ -5,9 +5,9 @@
+ func corge(f func(s *m.S)) {}
+
+ func plugh() {
+-	foovar := m.Foo
++	foovar := m.S.Foo1
+ 	_ = foovar
+-	barvar := m.Bar
+-	corge(m.Bar)
++	barvar := (*m.S).Bar1
++	corge((*m.S).Bar1)
+ 	corge(barvar)
+ }

--- a/testdata/mv_func_to_method4.txt
+++ b/testdata/mv_func_to_method4.txt
@@ -1,0 +1,43 @@
+mv Foo S.Foo1
+-- p.go --
+package m
+
+type S struct{}
+
+func Foo(s S) {}
+
+func xyzzy() {
+	funcvar := Foo
+	_ = funcvar
+}
+-- q/q.go --
+package q
+
+import "m"
+
+type S struct{}
+
+func Foo(s S) {}
+
+func plugh() {
+	funcvar := Foo
+	_ = funcvar
+	corge := m.S{}
+	_ = corge
+}
+-- stdout --
+diff old/p.go new/p.go
+--- old/p.go
++++ new/p.go
+@@ -2,9 +2,9 @@
+
+ type S struct{}
+
+-func Foo(s S) {}
++func (s S) Foo1() {}
+
+ func xyzzy() {
+-	funcvar := Foo
++	funcvar := S.Foo1
+ 	_ = funcvar
+ }

--- a/testdata/mv_func_to_method5.txt
+++ b/testdata/mv_func_to_method5.txt
@@ -1,0 +1,52 @@
+mv Foo S1.Bar
+-- p.go --
+package m
+
+type S1 struct{}
+
+type S2 struct {
+	X S1
+}
+
+var Corge S2
+
+func Foo(s S1) {}
+
+func xyzzy() {
+	funcvar := Foo
+	_ = funcvar
+}
+-- q/q.go --
+package q
+
+import "m"
+
+func plugh() {
+	m.Foo(m.Corge.X)
+}
+-- stdout --
+diff old/p.go new/p.go
+--- old/p.go
++++ new/p.go
+@@ -8,9 +8,9 @@
+
+ var Corge S2
+
+-func Foo(s S1) {}
++func (s S1) Bar() {}
+
+ func xyzzy() {
+-	funcvar := Foo
++	funcvar := S1.Bar
+ 	_ = funcvar
+ }
+diff old/q/q.go new/q/q.go
+--- old/q/q.go
++++ new/q/q.go
+@@ -3,5 +3,5 @@
+ import "m"
+
+ func plugh() {
+-	m.Foo(m.Corge.X)
++	m.Corge.X.Bar()
+ }


### PR DESCRIPTION
This change implements the 'mv TFunction T.Method' command.