### PR TITLE
rf: allow for custom go executable

### DIFF
--- a/refactor/config.go
+++ b/refactor/config.go
@@ -58,10 +58,10 @@ var platformsOnce struct {
 	err  error
 }
 
-func platforms() ([]goosGoarch, error) {
+func platforms(goBinary string) ([]goosGoarch, error) {
 	platformsOnce.once.Do(func() {
 		var platforms []goosGoarch
-		cmd := exec.Command("go", "tool", "dist", "list", "-json")
+		cmd := exec.Command(goBinary, "tool", "dist", "list", "-json")
 		if err := readJSON(cmd, &platforms); err != nil {
 			platformsOnce.err = fmt.Errorf("getting GOOS/GOARCH values: %w", err)
 			return
@@ -96,8 +96,8 @@ func (cs Configs) Plus(cs2 Configs) Configs {
 
 // ConfigsAllPlatforms returns a Configs for all GOOS/GOARCH combinations,
 // including covering both cgo and non-cgo where possible.
-func ConfigsAllPlatforms() (Configs, error) {
-	plats, err := platforms()
+func ConfigsAllPlatforms(goBinary string) (Configs, error) {
+	plats, err := platforms(goBinary)
 	if err != nil {
 		return Configs{}, err
 	}
@@ -133,8 +133,8 @@ func (c Config) String() string {
 
 // flagsEnvs returns the flags and environment variables to pass to go build to
 // produce this build configuration.
-func (c Config) flagsEnvs() (flags, envs []string, err error) {
-	plats, err := platforms()
+func (c Config) flagsEnvs(goBinary string) (flags, envs []string, err error) {
+	plats, err := platforms(goBinary)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/refactor/refactor.go
+++ b/refactor/refactor.go
@@ -25,9 +25,10 @@ type Refactor struct {
 	// but a caller can overwrite this.
 	Configs Configs
 
-	dir     string
-	modRoot string
-	modPath string
+	dir      string
+	modRoot  string
+	modPath  string
+	goBinary string
 
 	cache *buildCache
 
@@ -53,6 +54,10 @@ func (r *Refactor) PkgDir(pkg string) (string, error) {
 	return filepath.Join(r.modRoot, pkg[len(r.modPath)+1:]), nil
 }
 
+func (r *Refactor) GoBinary(path string) {
+	r.goBinary = path
+}
+
 // New returns a new refactoring,
 // editing the package in the given directory (usually ".").
 func New(dir string) (*Refactor, error) {
@@ -69,11 +74,12 @@ func New(dir string) (*Refactor, error) {
 	dir = d
 
 	r := &Refactor{
-		Stdout:  os.Stdout,
-		Stderr:  os.Stderr,
-		Debug:   make(map[string]string),
-		Configs: Configs{c: []Config{{}}},
-		dir:     dir,
+		Stdout:   os.Stdout,
+		Stderr:   os.Stderr,
+		Debug:    make(map[string]string),
+		Configs:  Configs{c: []Config{{}}},
+		dir:      dir,
+		goBinary: "go",
 	}
 	fset := token.NewFileSet()
 	r.cache = &buildCache{

--- a/refactor/snap.go
+++ b/refactor/snap.go
@@ -173,7 +173,7 @@ func (r *Refactor) load1(config Config) ([]*Snapshot, error) {
 	}
 	dir = filepath.Clean(dir)
 
-	cmd := exec.Command("go", "env", "GOMOD")
+	cmd := exec.Command(r.goBinary, "env", "GOMOD")
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), "PWD="+dir)
 	bmod, err := cmd.CombinedOutput()
@@ -186,7 +186,7 @@ func (r *Refactor) load1(config Config) ([]*Snapshot, error) {
 	}
 	r.modRoot = filepath.Dir(mod)
 
-	cmd = exec.Command("go", "mod", "edit", "-json")
+	cmd = exec.Command(r.goBinary, "mod", "edit", "-json")
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), "PWD="+dir)
 	js, err := cmd.CombinedOutput()
@@ -204,12 +204,12 @@ func (r *Refactor) load1(config Config) ([]*Snapshot, error) {
 	r.modPath = m.Module.Path
 	isStd := r.modPath == "std" || r.modPath == "cmd"
 
-	cfgFlags, cfgEnvs, err := config.flagsEnvs()
+	cfgFlags, cfgEnvs, err := config.flagsEnvs(r.goBinary)
 	if err != nil {
 		return nil, err
 	}
 	cmdList := append(append([]string{"list", "-e", "-pgo=off", "-json", "-compiled", "-test", "-deps"}, cfgFlags...), "./...")
-	cmd = exec.Command("go", cmdList...)
+	cmd = exec.Command(r.goBinary, cmdList...)
 	cmd.Dir = r.modRoot
 	cmd.Env = append(append(os.Environ(), "PWD="+r.modRoot), cfgEnvs...)
 	var stdout, stderr bytes.Buffer
@@ -489,7 +489,7 @@ func (r *Refactor) load1(config Config) ([]*Snapshot, error) {
 		}
 		sort.Strings(paths)
 		cmdList := append(append([]string{"list", "-e", "-json", "-export", "-test", "-deps"}, cfgFlags...), paths...)
-		cmd = exec.Command("go", cmdList...)
+		cmd = exec.Command(r.goBinary, cmdList...)
 		cmd.Dir = r.modRoot
 		cmd.Env = append(append(os.Environ(), "PWD="+r.modRoot), cfgEnvs...)
 		var stdout, stderr bytes.Buffer

--- a/rf_test.go
+++ b/rf_test.go
@@ -93,8 +93,10 @@ func TestReadLine(t *testing.T) {
 	}
 }
 
-var updateTestData = flag.Bool("u", false, "update testdata instead of failing")
-var flagKeep = flag.Bool("keep", false, "keep temporary work directories")
+var (
+	updateTestData = flag.Bool("u", false, "update testdata instead of failing")
+	flagKeep       = flag.Bool("keep", false, "keep temporary work directories")
+)
 
 func TestRun(t *testing.T) {
 	files, err := filepath.Glob("testdata/*.txt")
@@ -124,7 +126,7 @@ func TestRun(t *testing.T) {
 			} else {
 				dir = t.TempDir()
 			}
-			if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module m\n"), 0666); err != nil {
+			if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module m\n"), 0o666); err != nil {
 				t.Fatal(err)
 			}
 			var wantStdout, wantStderr txtar.File
@@ -138,10 +140,10 @@ func TestRun(t *testing.T) {
 					continue
 				}
 				targ := filepath.Join(dir, file.Name)
-				if err := os.MkdirAll(filepath.Dir(targ), 0777); err != nil {
+				if err := os.MkdirAll(filepath.Dir(targ), 0o777); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(targ, file.Data, 0666); err != nil {
+				if err := os.WriteFile(targ, file.Data, 0o666); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -196,7 +198,7 @@ func TestRun(t *testing.T) {
 				stderrChanged := updateFile(ar, "stderr", stderr.Bytes())
 				stdoutChanged := updateFile(ar, "stdout", stdout.Bytes())
 				if stdoutChanged || stderrChanged {
-					if err := os.WriteFile(file, txtar.Format(ar), 0666); err != nil {
+					if err := os.WriteFile(file, txtar.Format(ar), 0o666); err != nil {
 						t.Fatal(err)
 					}
 					t.Log("updated")

--- a/testdata/issue16.txt
+++ b/testdata/issue16.txt
@@ -1,0 +1,8 @@
+# Test that -go flag is populated properly.
+-go=go2
+add m.go // foo
+-- m.go --
+package m
+-- stderr --
+errors found before executing script: loading module: exec: "go2": executable file not found in $PATH
+


### PR DESCRIPTION
This change adds a flag `-go=x` that will allow the user to execute the binary specified rather than always searching PATH for an executable named "go".  The user can specify a relative or absolute path to an executable, or can search PATH for an alternate executable name.

The default value of the flag is "go", which preserves existing behavior by searching PATH for an executable named "go".

Examples:
  rf -go=go2   # will search PATH for an executable named go2
  rf -go=./go2 # will execute the binary go2 in the current directory
  rf -go=../some/path/go  # user gives a relative path to go
  rf -go=/some/path/to/go # user gives an absolute path to go

Fixes #16.